### PR TITLE
Sync timestamp between PLY and images

### DIFF
--- a/LiDARSense/ContentView.swift
+++ b/LiDARSense/ContentView.swift
@@ -218,6 +218,9 @@ extension ContentView: View {
                 
                 HStack {
                     Button(action: {
+                        let dateFormatter = DateFormatter()
+                        dateFormatter.dateFormat = "yyyy-MM-dd-HH-mm-ss"
+                        self.currentTimestamp = dateFormatter.string(from: Date())
                         self.isTakingPointCloud = true
                         savePlyFile()
                         let recordStartSoundID: SystemSoundID = 1117
@@ -241,6 +244,7 @@ extension ContentView: View {
                         let recordStartSoundID: SystemSoundID = 1118
                         AudioServicesPlaySystemSound(recordStartSoundID)
                         captureImage()
+                        self.currentTimestamp = nil
                     }, label: {
                         Text("Stop")
                             .foregroundColor(.white)


### PR DESCRIPTION
## Summary
- ensure capture operations share the same timestamp
- clear timestamp when capture cycle completes

## Testing
- `git status --short`