### PR TITLE
Fix typo in README license link

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,4 +27,4 @@
 
 ## ライセンス
 
-[MIT Licesne](./LICENSE)
+[MIT License](./LICENSE)


### PR DESCRIPTION
## Summary
- fix typo in the License section of the README

## Testing
- `git status --short`
